### PR TITLE
hotfix: Adjust sql to take users into account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* [PR-29](https://github.com/ITK-Leantime/leantime-timetable/pull/29)
+  * Fixed user specificity in timetable update sql
+
 ## [2.0.1] - 2024-10-23
 
 * [PR-27](https://github.com/ITK-Leantime/leantime-timetable/pull/27)


### PR DESCRIPTION
#### Link to ticket

N/A

#### Description

Saving timesheets did unfortunately not take userIds into account, causing users to overwrite each others time logs. Shame.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
