### PR TITLE
feature: Add language fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* [PR-45](https://github.com/ITK-Leantime/leantime-timetable/pull/45)
+  * Add fallback to unsupported languages
+
 * [PR-44](https://github.com/ITK-Leantime/leantime-timetable/pull/44)
   * Update changelog
   * Add new markdown lint

--- a/Middleware/GetLanguageAssets.php
+++ b/Middleware/GetLanguageAssets.php
@@ -7,26 +7,29 @@ use Closure;
 use Illuminate\Support\Facades\Cache;
 use Leantime\Core\Configuration\Environment as Configuration;
 use Leantime\Core\Http\IncomingRequest;
+use Psr\SimpleCache\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Response;
 use Leantime\Core\Language;
 
 /**
  * https://github.com/Leantime/plugin-template/blob/main/Middleware/GetLanguageAssets.php
  */
-class GetLanguageAssets
+readonly class GetLanguageAssets
 {
     /**
      * Constructor.
      */
     public function __construct(
-        private Language $language,
+        private Language      $language,
         private Configuration $config,
     ) {
     }
 
     /**
      * @param \Closure(IncomingRequest): Response $next
-     **/
+     *
+     * @throws InvalidArgumentException
+     */
     public function handle(IncomingRequest $request, Closure $next): Response
     {
 
@@ -41,11 +44,15 @@ class GetLanguageAssets
         }
 
         // @phpstan-ignore-next-line
-        if (($language = session('usersettings.language') ?? $this->config->language) !== 'en-US') {
-            if (! Cache::store('installation')->has('timeTable.language.' . $language)) {
+        if (($language = $this->config->language ?? session('usersettings.language')) !== 'en-US') {
+            if (!Cache::store('installation')->has('timeTable.language.' . $language)) {
+                $languageIniPath = __DIR__ . '/../Language/' . $language . '.ini';
+                if (!file_exists($languageIniPath)) {
+                    $languageIniPath = __DIR__ . '/../Language/en-US.ini';
+                }
                 Cache::store('installation')->put(
                     'timeTable.language.' . $language,
-                    parse_ini_file(__DIR__ . '/../Language/' . $language . '.ini', true)
+                    parse_ini_file($languageIniPath, true)
                 );
             }
 

--- a/Middleware/GetLanguageAssets.php
+++ b/Middleware/GetLanguageAssets.php
@@ -43,7 +43,6 @@ readonly class GetLanguageAssets
             $languageArray += parse_ini_file(__DIR__ . '/../Language/en-US.ini', true);
         }
 
-        // @phpstan-ignore-next-line
         if (($language = $this->config->language ?? session('usersettings.language')) !== 'en-US') {
             if (!Cache::store('installation')->has('timeTable.language.' . $language)) {
                 $languageIniPath = __DIR__ . '/../Language/' . $language . '.ini';


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/dashboard/show#/tickets/showTicket/4029

#### Description

Trying to install or use a plugin with a language selected which is not either da-DK og en-US will cause an error. We should fallback to en-US if no .ini file matches currently selected language.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
