### PR TITLE
Hotfix: hoursLeft as float instead of int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* [PR-63](https://github.com/ITK-Leantime/leantime-timetable/pull/63)
+  Hotfix: parse hoursLeft as float
+
 * [PR-61](https://github.com/ITK-Leantime/leantime-timetable/pull/61)
   Correct hours-remaining value
 

--- a/Controllers/TimeTable.php
+++ b/Controllers/TimeTable.php
@@ -222,7 +222,7 @@ class TimeTable extends Controller
                     $timesheetsSortedByWeekdate['projectName'] = $timesheetsByTicketAndDate[0]['name'];
                     $timesheetsSortedByWeekdate['ticketType'] = $timesheetsByTicketAndDate[0]['ticketType'];
                     $timesheetsSortedByWeekdate['ticketId'] = $timesheetsByTicketAndDate[0]['ticketId'];
-                    $timesheetsSortedByWeekdate['hourRemaining'] = (int) $timesheetsByTicketAndDate[0]['planHours'] - (int) $timesheetsByTicketAndDate[0]['hoursSum'];
+                    $timesheetsSortedByWeekdate['hourRemaining'] = (float) $timesheetsByTicketAndDate[0]['planHours'] - (float) $timesheetsByTicketAndDate[0]['hoursSum'];
                 }
             }
 

--- a/assets/timeTable.js
+++ b/assets/timeTable.js
@@ -196,7 +196,7 @@ jQuery(document).ready(function ($) {
           const ticketId = target.dataset.ticketid ?? null;
           const hours = target.dataset.hours ?? null;
           const headline = target.dataset.headline ?? null;
-          const hoursLeft = parseInt(target.dataset.hoursleft) ?? null;
+          const hoursLeft = parseFloat(target.dataset.hoursleft) ?? null;
           const description = target.dataset.description ?? null;
           const date = target.dataset.date ?? null;
 


### PR DESCRIPTION
#### Link to ticket

N/A

#### Description

Handle hoursLeft as float instead of int to not round.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
